### PR TITLE
Create, Update Workflows

### DIFF
--- a/app/api/workflow/[id]/route.ts
+++ b/app/api/workflow/[id]/route.ts
@@ -8,6 +8,13 @@ export async function GET(request: NextRequest) {
         const { pathname } = new URL(request.url);
         const id = pathname.split('/').pop();
 
+        if (!id) {
+            return NextResponse.json(
+                { error: 'Missing workflow ID' },
+                { status: 400 }
+            );
+        }
+
         const workflow = await store.getWorkflow(id);
         if (!workflow) {
             return NextResponse.json(
@@ -29,6 +36,13 @@ export async function PUT(request: NextRequest) {
     try {
         const { pathname } = new URL(request.url);
         const id = pathname.split('/').pop();
+        
+        if (!id) {
+            return NextResponse.json(
+                { error: 'Missing workflow ID' },
+                { status: 400 }
+            );
+        }
 
         const updates = await request.json();
         
@@ -53,6 +67,13 @@ export async function DELETE(request: NextRequest) {
     try {
         const { pathname } = new URL(request.url);
         const id = pathname.split('/').pop();
+        
+        if (!id) {
+            return NextResponse.json(
+                { error: 'Missing workflow ID' },
+                { status: 400 }
+            );
+        }
 
         const success = await store.deleteWorkflow(id);
         if (!success) {

--- a/app/api/workflow/[id]/route.ts
+++ b/app/api/workflow/[id]/route.ts
@@ -3,12 +3,12 @@ import { WorkflowStore } from '@/app/lib/workflow-store';
 
 const store = WorkflowStore.getInstance();
 
-export async function GET(
-    request: NextRequest,
-    context: { params: { id: string } }
-) {
+export async function GET(request: NextRequest) {
     try {
-        const workflow = await store.getWorkflow(context.params.id);
+        const { pathname } = new URL(request.url);
+        const id = pathname.split('/').pop();
+
+        const workflow = await store.getWorkflow(id);
         if (!workflow) {
             return NextResponse.json(
                 { error: 'Workflow not found' },
@@ -25,15 +25,15 @@ export async function GET(
     }
 }
 
-export async function PUT(
-    request: NextRequest,
-    context: { params: { id: string } }
-) {
+export async function PUT(request: NextRequest) {
     try {
+        const { pathname } = new URL(request.url);
+        const id = pathname.split('/').pop();
+
         const updates = await request.json();
         
         // Ensure ID matches
-        updates.id = context.params.id;
+        updates.id = id;
         
         // Update timestamps
         updates.updatedAt = new Date().toISOString();
@@ -49,12 +49,12 @@ export async function PUT(
     }
 }
 
-export async function DELETE(
-    request: NextRequest,
-    context: { params: { id: string } }
-) {
+export async function DELETE(request: NextRequest) {
     try {
-        const success = await store.deleteWorkflow(context.params.id);
+        const { pathname } = new URL(request.url);
+        const id = pathname.split('/').pop();
+
+        const success = await store.deleteWorkflow(id);
         if (!success) {
             return NextResponse.json(
                 { error: 'Workflow not found' },

--- a/app/api/workflow/[id]/route.ts
+++ b/app/api/workflow/[id]/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { WorkflowStore } from '@/app/lib/workflow-store';
+
+const store = WorkflowStore.getInstance();
+
+export async function GET(
+    request: NextRequest,
+    { params }: { params: { id: string } }
+) {
+    try {
+        const workflow = await store.getWorkflow(params.id);
+        if (!workflow) {
+            return NextResponse.json(
+                { error: 'Workflow not found' },
+                { status: 404 }
+            );
+        }
+        return NextResponse.json(workflow);
+    } catch (error) {
+        console.error('Failed to get workflow:', error);
+        return NextResponse.json(
+            { error: 'Failed to get workflow' },
+            { status: 500 }
+        );
+    }
+}
+
+export async function PUT(
+    request: NextRequest,
+    { params }: { params: { id: string } }
+) {
+    try {
+        const updates = await request.json();
+        
+        // Ensure ID matches
+        updates.id = params.id;
+        
+        // Update timestamps
+        updates.updatedAt = new Date().toISOString();
+        
+        const updated = await store.createWorkflow(updates);
+        return NextResponse.json(updated);
+    } catch (error) {
+        console.error('Failed to update workflow:', error);
+        return NextResponse.json(
+            { error: 'Failed to update workflow' },
+            { status: 500 }
+        );
+    }
+}
+
+export async function DELETE(
+    request: NextRequest,
+    { params }: { params: { id: string } }
+) {
+    try {
+        const success = await store.deleteWorkflow(params.id);
+        if (!success) {
+            return NextResponse.json(
+                { error: 'Workflow not found' },
+                { status: 404 }
+            );
+        }
+        return NextResponse.json({ success: true });
+    } catch (error) {
+        console.error('Failed to delete workflow:', error);
+        return NextResponse.json(
+            { error: 'Failed to delete workflow' },
+            { status: 500 }
+        );
+    }
+} 

--- a/app/api/workflow/[id]/route.ts
+++ b/app/api/workflow/[id]/route.ts
@@ -5,10 +5,10 @@ const store = WorkflowStore.getInstance();
 
 export async function GET(
     request: NextRequest,
-    { params }: { params: { id: string } }
+    context: { params: { id: string } }
 ) {
     try {
-        const workflow = await store.getWorkflow(params.id);
+        const workflow = await store.getWorkflow(context.params.id);
         if (!workflow) {
             return NextResponse.json(
                 { error: 'Workflow not found' },
@@ -27,13 +27,13 @@ export async function GET(
 
 export async function PUT(
     request: NextRequest,
-    { params }: { params: { id: string } }
+    context: { params: { id: string } }
 ) {
     try {
         const updates = await request.json();
         
         // Ensure ID matches
-        updates.id = params.id;
+        updates.id = context.params.id;
         
         // Update timestamps
         updates.updatedAt = new Date().toISOString();
@@ -51,10 +51,10 @@ export async function PUT(
 
 export async function DELETE(
     request: NextRequest,
-    { params }: { params: { id: string } }
+    context: { params: { id: string } }
 ) {
     try {
-        const success = await store.deleteWorkflow(params.id);
+        const success = await store.deleteWorkflow(context.params.id);
         if (!success) {
             return NextResponse.json(
                 { error: 'Workflow not found' },

--- a/app/api/workflow/[id]/task/[taskId]/route.ts
+++ b/app/api/workflow/[id]/task/[taskId]/route.ts
@@ -3,16 +3,18 @@ import { WorkflowStore } from '@/app/lib/workflow-store';
 
 const store = WorkflowStore.getInstance();
 
-export async function POST(
-    request: NextRequest,
-    { params }: { params: { id: string; taskId: string } }
-) {
+export async function POST(request: NextRequest) {
     try {
+        const { pathname } = new URL(request.url);
+        const parts = pathname.split('/');
+        const taskId = parts.pop();
+        const id = parts[parts.length - 2]; // Get the workflow ID, which is 2 segments before the end
+        
         const updates = await request.json();
         
         const workflow = await store.updateWorkflowTask(
-            params.id,
-            params.taskId,
+            id,
+            taskId,
             updates
         );
 

--- a/app/api/workflow/[id]/task/[taskId]/route.ts
+++ b/app/api/workflow/[id]/task/[taskId]/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { WorkflowStore } from '@/app/lib/workflow-store';
+
+const store = WorkflowStore.getInstance();
+
+export async function POST(
+    request: NextRequest,
+    { params }: { params: { id: string; taskId: string } }
+) {
+    try {
+        const updates = await request.json();
+        
+        const workflow = await store.updateWorkflowTask(
+            params.id,
+            params.taskId,
+            updates
+        );
+
+        if (!workflow) {
+            return NextResponse.json(
+                { error: 'Workflow or task not found' },
+                { status: 404 }
+            );
+        }
+
+        return NextResponse.json(workflow);
+    } catch (error) {
+        console.error('Failed to update task:', error);
+        return NextResponse.json(
+            { error: 'Failed to update task' },
+            { status: 500 }
+        );
+    }
+} 

--- a/app/api/workflow/[id]/task/[taskId]/route.ts
+++ b/app/api/workflow/[id]/task/[taskId]/route.ts
@@ -10,6 +10,14 @@ export async function POST(request: NextRequest) {
         const taskId = parts.pop();
         const id = parts[parts.length - 2]; // Get the workflow ID, which is 2 segments before the end
         
+        // Add validation for taskId and id
+        if (!taskId || !id) {
+            return NextResponse.json(
+                { error: 'Invalid workflow or task ID' },
+                { status: 400 }
+            );
+        }
+        
         const updates = await request.json();
         
         const workflow = await store.updateWorkflowTask(

--- a/app/api/workflow/route.ts
+++ b/app/api/workflow/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { WorkflowStore } from '@/app/lib/workflow-store';
+import { Workflow, TaskStatus } from '@/app/types/workflow';
+import { randomUUID } from 'crypto';
+
+const store = WorkflowStore.getInstance();
+
+export async function GET() {
+    try {
+        const workflows = await store.listWorkflows();
+        return NextResponse.json(workflows);
+    } catch (error) {
+        console.error('Failed to list workflows:', error);
+        return NextResponse.json(
+            { error: 'Failed to list workflows' },
+            { status: 500 }
+        );
+    }
+}
+
+export async function POST(request: NextRequest) {
+    try {
+        const body = await request.json();
+        
+        // Validate required fields
+        if (!body.name || !Array.isArray(body.tasks)) {
+            return NextResponse.json(
+                { error: 'Invalid workflow: name and tasks are required' },
+                { status: 400 }
+            );
+        }
+
+        // Create workflow with generated ID and timestamps
+        const workflow: Workflow = {
+            id: randomUUID(),
+            name: body.name,
+            description: body.description,
+            tasks: body.tasks.map((task: any) => ({
+                ...task,
+                id: task.id || randomUUID(),
+                status: TaskStatus.NOT_STARTED,
+                createdAt: new Date().toISOString(),
+                updatedAt: new Date().toISOString()
+            })),
+            status: TaskStatus.NOT_STARTED,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+            metadata: body.metadata || {}
+        };
+
+        const created = await store.createWorkflow(workflow);
+        return NextResponse.json(created, { status: 201 });
+    } catch (error) {
+        console.error('Failed to create workflow:', error);
+        return NextResponse.json(
+            { error: 'Failed to create workflow' },
+            { status: 500 }
+        );
+    }
+} 

--- a/app/api/workflow/route.ts
+++ b/app/api/workflow/route.ts
@@ -35,7 +35,11 @@ export async function POST(request: NextRequest) {
             id: randomUUID(),
             name: body.name,
             description: body.description,
-            tasks: body.tasks.map((task: any) => ({
+            tasks: body.tasks.map((task: {
+                id?: string;
+                name: string;
+                description?: string;
+            }) => ({
                 ...task,
                 id: task.id || randomUUID(),
                 status: TaskStatus.NOT_STARTED,

--- a/app/components/WorkflowForm.tsx
+++ b/app/components/WorkflowForm.tsx
@@ -29,7 +29,6 @@ export default function WorkflowForm({ initialWorkflow }: WorkflowFormProps) {
             type: TaskType.READ_OBESITY_INTAKE_FORM,
             data: {
                 url: '',
-                formSelector: ''
             }
         }
     });
@@ -41,19 +40,19 @@ export default function WorkflowForm({ initialWorkflow }: WorkflowFormProps) {
             case TaskType.READ_OBESITY_INTAKE_FORM:
                 return {
                     type: TaskType.READ_OBESITY_INTAKE_FORM,
-                    data: { url: '', formSelector: '' }
+                    data: { url: '' }
                 };
             case TaskType.VALIDATE_DATA:
                 return {
                     type: TaskType.VALIDATE_DATA,
                     data: { 
-                        validationFn: (data: any) => true // Default validation function that always returns true
+                        validationFn: () => true
                     }
                 };
             default:
                 return {
                     type: TaskType.READ_OBESITY_INTAKE_FORM,
-                    data: { url: '', formSelector: '' }
+                    data: { url: '' }
                 };
         }
     };
@@ -84,7 +83,6 @@ export default function WorkflowForm({ initialWorkflow }: WorkflowFormProps) {
                 type: TaskType.READ_OBESITY_INTAKE_FORM,
                 data: {
                     url: '',
-                    formSelector: ''
                 }
             }
         });
@@ -150,28 +148,10 @@ export default function WorkflowForm({ initialWorkflow }: WorkflowFormProps) {
                                 onChange={e => onChange({
                                     type: TaskType.READ_OBESITY_INTAKE_FORM,
                                     data: {
-                                        ...input.data,
-                                        url: e.target.value,
-                                        formSelector: (input.data as any).formSelector || ''
+                                        url: e.target.value
                                     }
                                 })}
                                 className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2"
-                            />
-                        </div>
-                        <div>
-                            <label className="block text-sm text-gray-700">Form Selector</label>
-                            <input
-                                type="text"
-                                value={input.type === TaskType.READ_OBESITY_INTAKE_FORM ? input.data.formSelector : ''}
-                                onChange={e => onChange({
-                                    type: TaskType.READ_OBESITY_INTAKE_FORM,
-                                    data: {
-                                        ...input.data,
-                                        formSelector: e.target.value
-                                    }
-                                })}
-                                className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2"
-                                placeholder="CSS selector for the form"
                             />
                         </div>
                     </div>
@@ -199,11 +179,9 @@ export default function WorkflowForm({ initialWorkflow }: WorkflowFormProps) {
         switch (task.type) {
             case TaskType.READ_OBESITY_INTAKE_FORM:
                 return (
-                    <>
-                        <p className="text-sm text-gray-600">
-                            URL: {task.input.type === TaskType.READ_OBESITY_INTAKE_FORM && task.input.data.url}
-                        </p>
-                    </>
+                    <p className="text-sm text-gray-600">
+                        URL: {task.input.type === TaskType.READ_OBESITY_INTAKE_FORM && task.input.data.url}
+                    </p>
                 );
             
             case TaskType.VALIDATE_DATA:
@@ -291,7 +269,6 @@ export default function WorkflowForm({ initialWorkflow }: WorkflowFormProps) {
                                         type: TaskType.READ_OBESITY_INTAKE_FORM,
                                         data: {
                                             url: '',
-                                            formSelector: ''
                                         }
                                     }
                                 });

--- a/app/components/WorkflowForm.tsx
+++ b/app/components/WorkflowForm.tsx
@@ -1,0 +1,398 @@
+'use client';
+
+import { useState } from 'react';
+import { Workflow, Task, TaskType, TaskInput, TaskStatus } from '../types/workflow';
+import { useRouter } from 'next/navigation';
+
+interface WorkflowFormProps {
+    initialWorkflow?: Workflow;
+}
+
+export default function WorkflowForm({ initialWorkflow }: WorkflowFormProps) {
+    const router = useRouter();
+    const [error, setError] = useState<string | null>(null);
+    const [loading, setLoading] = useState(false);
+
+    const [workflow, setWorkflow] = useState<Partial<Workflow>>(
+        initialWorkflow || {
+            name: '',
+            description: '',
+            tasks: [],
+            metadata: {}
+        }
+    );
+
+    const [newTask, setNewTask] = useState<Partial<Task>>({
+        type: TaskType.READ_OBESITY_INTAKE_FORM,
+        description: '',
+        input: {
+            type: TaskType.READ_OBESITY_INTAKE_FORM,
+            data: {
+                url: '',
+                formSelector: ''
+            }
+        }
+    });
+
+    const [showTaskForm, setShowTaskForm] = useState(false);
+
+    const getDefaultInputForTaskType = (type: TaskType): TaskInput => {
+        switch (type) {
+            case TaskType.READ_OBESITY_INTAKE_FORM:
+                return {
+                    type: TaskType.READ_OBESITY_INTAKE_FORM,
+                    data: { url: '', formSelector: '' }
+                };
+            case TaskType.VALIDATE_DATA:
+                return {
+                    type: TaskType.VALIDATE_DATA,
+                    data: { 
+                        validationFn: (data: any) => true // Default validation function that always returns true
+                    }
+                };
+            default:
+                return {
+                    type: TaskType.READ_OBESITY_INTAKE_FORM,
+                    data: { url: '', formSelector: '' }
+                };
+        }
+    };
+
+    const addTask = () => {
+        if (!newTask.type || !newTask.input || !newTask.description) return;
+
+        const task: Task = {
+            id: crypto.randomUUID(),
+            type: newTask.type,
+            description: newTask.description,
+            status: TaskStatus.NOT_STARTED,
+            input: newTask.input as TaskInput,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString()
+        };
+
+        setWorkflow(prev => ({
+            ...prev,
+            tasks: [...(prev.tasks || []), task]
+        }));
+
+        // Reset new task form
+        setNewTask({
+            type: TaskType.READ_OBESITY_INTAKE_FORM,
+            description: '',
+            input: {
+                type: TaskType.READ_OBESITY_INTAKE_FORM,
+                data: {
+                    url: '',
+                    formSelector: ''
+                }
+            }
+        });
+    };
+
+    const removeTask = (taskId: string) => {
+        setWorkflow(prev => ({
+            ...prev,
+            tasks: prev.tasks?.filter(t => t.id !== taskId) || []
+        }));
+    };
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        setLoading(true);
+        setError(null);
+
+        try {
+            const method = initialWorkflow ? 'PUT' : 'POST';
+            const url = initialWorkflow 
+                ? `/api/workflow/${initialWorkflow.id}`
+                : '/api/workflow';
+
+            const response = await fetch(url, {
+                method,
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify(workflow)
+            });
+
+            if (!response.ok) {
+                throw new Error('Failed to save workflow');
+            }
+
+            router.push('/workflows');
+        } catch (err) {
+            setError(err instanceof Error ? err.message : 'Failed to save workflow');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    // Add this new type-safe component for task input forms
+    const TaskInputForm = ({ 
+        taskType, 
+        input, 
+        onChange 
+    }: { 
+        taskType: TaskType;
+        input: TaskInput;
+        onChange: (input: TaskInput) => void;
+    }) => {
+        switch (taskType) {
+            case TaskType.READ_OBESITY_INTAKE_FORM:
+                return (
+                    <div className="space-y-3">
+                        <div>
+                            <label className="block text-sm text-gray-700">URL</label>
+                            <input
+                                type="url"
+                                value={input.type === TaskType.READ_OBESITY_INTAKE_FORM ? input.data.url : ''}
+                                onChange={e => onChange({
+                                    type: TaskType.READ_OBESITY_INTAKE_FORM,
+                                    data: {
+                                        ...input.data,
+                                        url: e.target.value,
+                                        formSelector: (input.data as any).formSelector || ''
+                                    }
+                                })}
+                                className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2"
+                            />
+                        </div>
+                        <div>
+                            <label className="block text-sm text-gray-700">Form Selector</label>
+                            <input
+                                type="text"
+                                value={input.type === TaskType.READ_OBESITY_INTAKE_FORM ? input.data.formSelector : ''}
+                                onChange={e => onChange({
+                                    type: TaskType.READ_OBESITY_INTAKE_FORM,
+                                    data: {
+                                        ...input.data,
+                                        formSelector: e.target.value
+                                    }
+                                })}
+                                className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2"
+                                placeholder="CSS selector for the form"
+                            />
+                        </div>
+                    </div>
+                );
+            
+            case TaskType.VALIDATE_DATA:
+                return (
+                    <div>
+                        <label className="block text-sm text-gray-700">Validation Function</label>
+                        <div className="mt-1 p-4 bg-gray-50 rounded-lg">
+                            <p className="text-sm text-gray-600">
+                                Validation function will be provided during task execution.
+                            </p>
+                        </div>
+                    </div>
+                );
+            
+            default:
+                return <div>Unsupported task type</div>;
+        }
+    };
+
+    // Add this component to display task details
+    const TaskDisplay = ({ task }: { task: Task }) => {
+        switch (task.type) {
+            case TaskType.READ_OBESITY_INTAKE_FORM:
+                return (
+                    <>
+                        <p className="text-sm text-gray-600">
+                            URL: {task.input.type === TaskType.READ_OBESITY_INTAKE_FORM && task.input.data.url}
+                        </p>
+                    </>
+                );
+            
+            case TaskType.VALIDATE_DATA:
+                return (
+                    <p className="text-sm text-gray-600">
+                        Validation task
+                    </p>
+                );
+                
+            default:
+                return <p className="text-sm text-gray-600">Unsupported task type</p>;
+        }
+    };
+
+    return (
+        <form onSubmit={handleSubmit} className="space-y-8">
+            {error && (
+                <div className="bg-red-50 border border-red-200 rounded-lg p-4 text-red-700">
+                    {error}
+                </div>
+            )}
+
+            <div className="space-y-4">
+                <div>
+                    <label htmlFor="name" className="block text-sm font-medium text-gray-700">
+                        Name
+                    </label>
+                    <input
+                        type="text"
+                        id="name"
+                        value={workflow.name || ''}
+                        onChange={e => setWorkflow(prev => ({ ...prev, name: e.target.value }))}
+                        className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 focus:border-indigo-500 focus:ring-indigo-500"
+                        required
+                    />
+                </div>
+
+                <div>
+                    <label htmlFor="description" className="block text-sm font-medium text-gray-700">
+                        Description
+                    </label>
+                    <textarea
+                        id="description"
+                        value={workflow.description || ''}
+                        onChange={e => setWorkflow(prev => ({ ...prev, description: e.target.value }))}
+                        className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 focus:border-indigo-500 focus:ring-indigo-500"
+                        rows={3}
+                        required
+                        placeholder="Enter a detailed description of the workflow's purpose and expected outcomes..."
+                    />
+                </div>
+
+                <div>
+                    <h3 className="text-lg font-medium text-gray-900">Tasks</h3>
+                    <div className="mt-4 space-y-4">
+                        {workflow.tasks?.map((task) => (
+                            <div
+                                key={task.id}
+                                className="flex items-center justify-between p-4 bg-gray-50 rounded-lg"
+                            >
+                                <div className="flex-grow">
+                                    <p className="font-medium text-gray-900">{task.type}</p>
+                                    <p className="text-sm text-gray-600">
+                                        Description: {task.description}
+                                    </p>
+                                    <TaskDisplay task={task} />
+                                </div>
+                                <button
+                                    type="button"
+                                    onClick={() => removeTask(task.id)}
+                                    className="text-red-600 hover:text-red-700"
+                                >
+                                    Remove
+                                </button>
+                            </div>
+                        ))}
+
+                        <button
+                            type="button"
+                            onClick={() => {
+                                setNewTask({
+                                    type: TaskType.READ_OBESITY_INTAKE_FORM,
+                                    description: '',
+                                    input: {
+                                        type: TaskType.READ_OBESITY_INTAKE_FORM,
+                                        data: {
+                                            url: '',
+                                            formSelector: ''
+                                        }
+                                    }
+                                });
+                                setShowTaskForm(true);
+                            }}
+                            className="w-full mt-4 bg-indigo-50 text-indigo-600 px-4 py-2 rounded-lg hover:bg-indigo-100 flex items-center justify-center"
+                        >
+                            <svg className="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+                            </svg>
+                            Add Task
+                        </button>
+
+                        {showTaskForm && (
+                            <div className="border rounded-lg p-4 mt-4 bg-white">
+                                <div className="space-y-3">
+                                    <div>
+                                        <label className="block text-sm text-gray-700">Task Type</label>
+                                        <select
+                                            value={newTask.type}
+                                            onChange={e => {
+                                                const selectedType = e.target.value as TaskType;
+                                                setNewTask({
+                                                    type: selectedType,
+                                                    description: newTask.description || '',
+                                                    input: getDefaultInputForTaskType(selectedType)
+                                                });
+                                            }}
+                                            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2"
+                                        >
+                                            {Object.values(TaskType).map(type => (
+                                                <option key={type} value={type}>
+                                                    {type}
+                                                </option>
+                                            ))}
+                                        </select>
+                                    </div>
+                                    
+                                    <div>
+                                        <label className="block text-sm text-gray-700">Task Description</label>
+                                        <textarea
+                                            value={newTask.description || ''}
+                                            onChange={e => setNewTask(prev => ({
+                                                ...prev,
+                                                description: e.target.value
+                                            }))}
+                                            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2"
+                                            rows={2}
+                                            placeholder="Describe the purpose of this task..."
+                                            required
+                                        />
+                                    </div>
+
+                                    <TaskInputForm
+                                        taskType={newTask.type!}
+                                        input={newTask.input as TaskInput}
+                                        onChange={(input) => setNewTask(prev => ({ ...prev, input }))}
+                                    />
+
+                                    <div className="flex justify-end space-x-2">
+                                        <button
+                                            type="button"
+                                            onClick={() => setShowTaskForm(false)}
+                                            className="px-4 py-2 text-gray-700 hover:text-gray-900"
+                                        >
+                                            Cancel
+                                        </button>
+                                        <button
+                                            type="button"
+                                            onClick={() => {
+                                                addTask();
+                                                setShowTaskForm(false);
+                                            }}
+                                            className="bg-indigo-600 text-white px-4 py-2 rounded-lg hover:bg-indigo-700"
+                                        >
+                                            Add Task
+                                        </button>
+                                    </div>
+                                </div>
+                            </div>
+                        )}
+                    </div>
+                </div>
+            </div>
+
+            <div className="flex justify-end space-x-3">
+                <button
+                    type="button"
+                    onClick={() => router.push('/workflows')}
+                    className="px-4 py-2 text-gray-700 hover:text-gray-900"
+                >
+                    Cancel
+                </button>
+                <button
+                    type="submit"
+                    disabled={loading}
+                    className="bg-indigo-600 text-white px-4 py-2 rounded-lg hover:bg-indigo-700 disabled:opacity-50"
+                >
+                    {loading ? 'Saving...' : (initialWorkflow ? 'Update' : 'Create')} Workflow
+                </button>
+            </div>
+        </form>
+    );
+} 

--- a/app/components/WorkflowList.tsx
+++ b/app/components/WorkflowList.tsx
@@ -1,0 +1,152 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Workflow, TaskStatus } from '../types/workflow';
+import Link from 'next/link';
+
+export default function WorkflowList() {
+    const [workflows, setWorkflows] = useState<Workflow[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        fetchWorkflows();
+    }, []);
+
+    const fetchWorkflows = async () => {
+        try {
+            const response = await fetch('/api/workflow');
+            if (!response.ok) throw new Error('Failed to fetch workflows');
+            const data = await response.json();
+            setWorkflows(data);
+        } catch (err) {
+            setError(err instanceof Error ? err.message : 'Failed to load workflows');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const deleteWorkflow = async (id: string) => {
+        if (!confirm('Are you sure you want to delete this workflow?')) return;
+        
+        try {
+            const response = await fetch(`/api/workflow/${id}`, {
+                method: 'DELETE'
+            });
+            if (!response.ok) throw new Error('Failed to delete workflow');
+            await fetchWorkflows();
+        } catch (err) {
+            setError(err instanceof Error ? err.message : 'Failed to delete workflow');
+        }
+    };
+
+    const getStatusColor = (status: TaskStatus) => {
+        switch (status) {
+            case TaskStatus.COMPLETED:
+                return 'bg-green-100 text-green-800';
+            case TaskStatus.IN_PROGRESS:
+                return 'bg-blue-100 text-blue-800';
+            case TaskStatus.FAILED:
+                return 'bg-red-100 text-red-800';
+            default:
+                return 'bg-gray-100 text-gray-800';
+        }
+    };
+
+    if (loading) {
+        return (
+            <div className="flex justify-center items-center min-h-[200px]">
+                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-600"></div>
+            </div>
+        );
+    }
+
+    if (error) {
+        return (
+            <div className="bg-red-50 border border-red-200 rounded-lg p-4 text-red-700">
+                {error}
+            </div>
+        );
+    }
+
+    return (
+        <div className="space-y-6">
+            <div className="flex justify-between items-center">
+                <h2 className="text-2xl font-bold text-gray-900">Workflows</h2>
+                <Link
+                    href="/workflows/new"
+                    className="bg-indigo-600 text-white px-4 py-2 rounded-lg hover:bg-indigo-700 transition-colors"
+                >
+                    Create New Workflow
+                </Link>
+            </div>
+
+            <div className="grid gap-6">
+                {workflows.map((workflow) => (
+                    <div
+                        key={workflow.id}
+                        className="bg-white rounded-lg shadow-sm border border-gray-200 p-6"
+                    >
+                        <div className="flex justify-between items-start">
+                            <div>
+                                <h3 className="text-xl font-semibold text-gray-900">
+                                    {workflow.name}
+                                </h3>
+                                {workflow.description && (
+                                    <p className="mt-1 text-gray-600">{workflow.description}</p>
+                                )}
+                            </div>
+                            <span className={`px-3 py-1 rounded-full text-sm font-medium ${getStatusColor(workflow.status)}`}>
+                                {workflow.status}
+                            </span>
+                        </div>
+
+                        <div className="mt-4">
+                            <h4 className="text-sm font-medium text-gray-700">Tasks ({workflow.tasks.length})</h4>
+                            <div className="mt-2 space-y-2">
+                                {workflow.tasks.map((task) => (
+                                    <div
+                                        key={task.id}
+                                        className="flex justify-between items-center p-3 bg-gray-50 rounded-lg"
+                                    >
+                                        <span className="text-sm text-gray-700">{task.type}</span>
+                                        <span className={`px-2 py-1 rounded-full text-xs font-medium ${getStatusColor(task.status)}`}>
+                                            {task.status}
+                                        </span>
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
+
+                        <div className="mt-6 flex justify-end space-x-3">
+                            <Link
+                                href={`/workflows/${workflow.id}`}
+                                className="text-indigo-600 hover:text-indigo-700 font-medium text-sm"
+                            >
+                                View Details
+                            </Link>
+                            <button
+                                onClick={() => deleteWorkflow(workflow.id)}
+                                className="text-red-600 hover:text-red-700 font-medium text-sm"
+                            >
+                                Delete
+                            </button>
+                        </div>
+                    </div>
+                ))}
+
+                {workflows.length === 0 && (
+                    <div className="text-center py-12 bg-gray-50 rounded-lg">
+                        <p className="text-gray-600">No workflows found</p>
+                        <Link
+                            href="/workflows/new"
+                            className="mt-2 inline-block text-indigo-600 hover:text-indigo-700 font-medium"
+                        >
+                            Create your first workflow
+                        </Link>
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+} 

--- a/app/lib/workflow-store.ts
+++ b/app/lib/workflow-store.ts
@@ -1,0 +1,115 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { Workflow, Task, TaskStatus } from '../types/workflow';
+
+const WORKFLOWS_DIR = path.join(process.cwd(), '.workflows');
+
+export class WorkflowStore {
+    private static instance: WorkflowStore;
+
+    private constructor() {
+        // Initialize store
+        this.ensureWorkflowsDir();
+    }
+
+    public static getInstance(): WorkflowStore {
+        if (!WorkflowStore.instance) {
+            WorkflowStore.instance = new WorkflowStore();
+        }
+        return WorkflowStore.instance;
+    }
+
+    private async ensureWorkflowsDir() {
+        try {
+            await fs.access(WORKFLOWS_DIR);
+        } catch {
+            await fs.mkdir(WORKFLOWS_DIR, { recursive: true });
+        }
+    }
+
+    private getWorkflowPath(id: string): string {
+        return path.join(WORKFLOWS_DIR, `${id}.json`);
+    }
+
+    async createWorkflow(workflow: Workflow): Promise<Workflow> {
+        const filePath = this.getWorkflowPath(workflow.id);
+        await fs.writeFile(filePath, JSON.stringify(workflow, null, 2));
+        return workflow;
+    }
+
+    async getWorkflow(id: string): Promise<Workflow | null> {
+        try {
+            const filePath = this.getWorkflowPath(id);
+            const data = await fs.readFile(filePath, 'utf-8');
+            return JSON.parse(data) as Workflow;
+        } catch (error) {
+            if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+                return null;
+            }
+            throw error;
+        }
+    }
+
+    async listWorkflows(): Promise<Workflow[]> {
+        const files = await fs.readdir(WORKFLOWS_DIR);
+        const workflows: Workflow[] = [];
+        
+        for (const file of files) {
+            if (file.endsWith('.json')) {
+                const data = await fs.readFile(path.join(WORKFLOWS_DIR, file), 'utf-8');
+                workflows.push(JSON.parse(data) as Workflow);
+            }
+        }
+        
+        return workflows;
+    }
+
+    async updateWorkflowTask(workflowId: string, taskId: string, updates: Partial<Task>): Promise<Workflow | null> {
+        const workflow = await this.getWorkflow(workflowId);
+        if (!workflow) return null;
+
+        const taskIndex = workflow.tasks.findIndex(t => t.id === taskId);
+        if (taskIndex === -1) return null;
+
+        // Update task
+        workflow.tasks[taskIndex] = {
+            ...workflow.tasks[taskIndex],
+            ...updates,
+            updatedAt: new Date().toISOString()
+        };
+
+        // Update workflow status based on tasks
+        workflow.status = this.calculateWorkflowStatus(workflow.tasks);
+        workflow.updatedAt = new Date().toISOString();
+
+        // Save updated workflow
+        await this.createWorkflow(workflow);
+        return workflow;
+    }
+
+    async deleteWorkflow(id: string): Promise<boolean> {
+        try {
+            const filePath = this.getWorkflowPath(id);
+            await fs.unlink(filePath);
+            return true;
+        } catch (error) {
+            if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+                return false;
+            }
+            throw error;
+        }
+    }
+
+    private calculateWorkflowStatus(tasks: Task[]): TaskStatus {
+        if (tasks.some(t => t.status === TaskStatus.FAILED)) {
+            return TaskStatus.FAILED;
+        }
+        if (tasks.every(t => t.status === TaskStatus.COMPLETED)) {
+            return TaskStatus.COMPLETED;
+        }
+        if (tasks.some(t => t.status === TaskStatus.IN_PROGRESS)) {
+            return TaskStatus.IN_PROGRESS;
+        }
+        return TaskStatus.NOT_STARTED;
+    }
+} 

--- a/app/types/workflow.ts
+++ b/app/types/workflow.ts
@@ -1,0 +1,97 @@
+// Task status enum
+export enum TaskStatus {
+    NOT_STARTED = 'NOT_STARTED',
+    IN_PROGRESS = 'IN_PROGRESS',
+    COMPLETED = 'COMPLETED',
+    FAILED = 'FAILED',
+}
+
+// Task type enum
+export enum TaskType {
+    READ_OBESITY_INTAKE_FORM = 'READ_OBESITY_INTAKE_FORM',
+    // Add more task types here as needed
+}
+
+// READ_OBESITY_INTAKE_FORM types
+interface ReadObesityIntakeFormData {
+    url: string;
+    formSelector?: string;
+}
+
+interface ReadObesityIntakeFormResult {
+    patientInfo?: {
+        name?: string;
+        dateOfBirth?: string;
+        height?: string;
+        weight?: string;
+        bmi?: string;
+        medicalHistory?: string[];
+        currentMedications?: string[];
+        allergies?: string[];
+        dietaryRestrictions?: string[];
+        exerciseRoutine?: {
+            frequency?: string;
+            type?: string;
+            duration?: string;
+        };
+        previousWeightLossAttempts?: {
+            method: string;
+            duration: string;
+            result: string;
+        }[];
+    };
+    formMetadata?: {
+        submissionDate?: string;
+        formVersion?: string;
+        completionStatus?: 'complete' | 'partial' | 'invalid';
+    };
+}
+
+// Discriminated unions for task inputs and outputs
+export type TaskInput = {
+    type: TaskType.READ_OBESITY_INTAKE_FORM;
+    data: ReadObesityIntakeFormData;
+} // | { type: OtherTaskType; data: OtherTaskData }
+
+export type TaskOutput = {
+    type: TaskType.READ_OBESITY_INTAKE_FORM;
+    success: boolean;
+    error?: string;
+    data?: ReadObesityIntakeFormResult;
+} // | { type: OtherTaskType; success: boolean; error?: string; data?: OtherTaskResult }
+
+// Task definition
+export interface Task {
+    id: string;
+    type: TaskType;
+    status: TaskStatus;
+    input: TaskInput;
+    output?: TaskOutput;
+    createdAt: string;
+    updatedAt: string;
+    error?: string;
+}
+
+// Workflow definition
+export interface Workflow {
+    id: string;
+    name: string;
+    description?: string;
+    tasks: Task[];
+    status: TaskStatus;
+    createdAt: string;
+    updatedAt: string;
+    metadata?: Record<string, any>;
+}
+
+// Helper types for type-safe task input/output access
+export type InputDataForType<T extends TaskType> = Extract<TaskInput, { type: T }>['data'];
+export type OutputDataForType<T extends TaskType> = Extract<TaskOutput, { type: T }>['data'];
+
+// Type guard functions
+export function isTaskOfType<T extends TaskType>(
+    type: T,
+    task: Task
+): task is Task & { type: T; input: Extract<TaskInput, { type: T }>; output?: Extract<TaskOutput, { type: T }> } {
+    return task.type === type;
+} 

--- a/app/types/workflow.ts
+++ b/app/types/workflow.ts
@@ -49,7 +49,7 @@ interface ReadObesityIntakeFormResult {
 
 // VALIDATE_DATA types
 interface ValidateDataInput {
-    validationFn: (data: any) => boolean;
+    validationFn: (data: unknown) => boolean;
 }
 
 interface ValidateDataResult {
@@ -99,7 +99,7 @@ export interface Workflow {
     status: TaskStatus;
     createdAt: string;
     updatedAt: string;
-    metadata?: Record<string, any>;
+    metadata?: Record<string, unknown>;
 }
 
 // Helper types for type-safe task input/output access

--- a/app/types/workflow.ts
+++ b/app/types/workflow.ts
@@ -9,13 +9,13 @@ export enum TaskStatus {
 // Task type enum
 export enum TaskType {
     READ_OBESITY_INTAKE_FORM = 'READ_OBESITY_INTAKE_FORM',
+    VALIDATE_DATA = 'VALIDATE_DATA',
     // Add more task types here as needed
 }
 
 // READ_OBESITY_INTAKE_FORM types
 interface ReadObesityIntakeFormData {
     url: string;
-    formSelector?: string;
 }
 
 interface ReadObesityIntakeFormResult {
@@ -47,23 +47,41 @@ interface ReadObesityIntakeFormResult {
     };
 }
 
+// VALIDATE_DATA types
+interface ValidateDataInput {
+    validationFn: (data: any) => boolean;
+}
+
+interface ValidateDataResult {
+    isValid: boolean;
+}
+
 // Discriminated unions for task inputs and outputs
 export type TaskInput = {
     type: TaskType.READ_OBESITY_INTAKE_FORM;
     data: ReadObesityIntakeFormData;
-} // | { type: OtherTaskType; data: OtherTaskData }
+} | {
+    type: TaskType.VALIDATE_DATA;
+    data: ValidateDataInput;
+}
 
 export type TaskOutput = {
     type: TaskType.READ_OBESITY_INTAKE_FORM;
     success: boolean;
     error?: string;
     data?: ReadObesityIntakeFormResult;
-} // | { type: OtherTaskType; success: boolean; error?: string; data?: OtherTaskResult }
+} | {
+    type: TaskType.VALIDATE_DATA;
+    success: boolean;
+    error?: string;
+    data?: ValidateDataResult;
+}
 
 // Task definition
 export interface Task {
     id: string;
     type: TaskType;
+    description: string;
     status: TaskStatus;
     input: TaskInput;
     output?: TaskOutput;
@@ -76,7 +94,7 @@ export interface Task {
 export interface Workflow {
     id: string;
     name: string;
-    description?: string;
+    description: string;
     tasks: Task[];
     status: TaskStatus;
     createdAt: string;

--- a/app/workflows/[id]/page.tsx
+++ b/app/workflows/[id]/page.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import WorkflowForm from '../../components/WorkflowForm';
+import { Workflow } from '../../types/workflow';
+
+export default function EditWorkflowPage() {
+    const params = useParams();
+    const [workflow, setWorkflow] = useState<Workflow | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        fetchWorkflow();
+    }, []);
+
+    const fetchWorkflow = async () => {
+        try {
+            const response = await fetch(`/api/workflow/${params.id}`);
+            if (!response.ok) throw new Error('Failed to fetch workflow');
+            const data = await response.json();
+            setWorkflow(data);
+        } catch (err) {
+            setError(err instanceof Error ? err.message : 'Failed to load workflow');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    if (loading) {
+        return (
+            <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+                <div className="flex justify-center items-center min-h-[200px]">
+                    <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-600"></div>
+                </div>
+            </div>
+        );
+    }
+
+    if (error || !workflow) {
+        return (
+            <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+                <div className="bg-red-50 border border-red-200 rounded-lg p-4 text-red-700">
+                    {error || 'Workflow not found'}
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+            <h1 className="text-3xl font-bold text-gray-900 mb-8">Edit Workflow</h1>
+            <WorkflowForm initialWorkflow={workflow} />
+        </div>
+    );
+} 

--- a/app/workflows/[id]/page.tsx
+++ b/app/workflows/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { useParams } from 'next/navigation';
 import WorkflowForm from '../../components/WorkflowForm';
 import { Workflow } from '../../types/workflow';
@@ -11,11 +11,7 @@ export default function EditWorkflowPage() {
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
 
-    useEffect(() => {
-        fetchWorkflow();
-    }, []);
-
-    const fetchWorkflow = async () => {
+    const fetchWorkflow = useCallback(async () => {
         try {
             const response = await fetch(`/api/workflow/${params.id}`);
             if (!response.ok) throw new Error('Failed to fetch workflow');
@@ -26,7 +22,11 @@ export default function EditWorkflowPage() {
         } finally {
             setLoading(false);
         }
-    };
+    }, [params.id]);
+
+    useEffect(() => {
+        fetchWorkflow();
+    }, [fetchWorkflow]);
 
     if (loading) {
         return (

--- a/app/workflows/new/page.tsx
+++ b/app/workflows/new/page.tsx
@@ -1,0 +1,10 @@
+import WorkflowForm from '../../components/WorkflowForm';
+
+export default function NewWorkflowPage() {
+    return (
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+            <h1 className="text-3xl font-bold text-gray-900 mb-8">Create New Workflow</h1>
+            <WorkflowForm />
+        </div>
+    );
+} 

--- a/app/workflows/page.tsx
+++ b/app/workflows/page.tsx
@@ -1,0 +1,9 @@
+import WorkflowList from '../components/WorkflowList';
+
+export default function WorkflowsPage() {
+    return (
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+            <WorkflowList />
+        </div>
+    );
+} 


### PR DESCRIPTION
Adds a simple, linear workflow type, allows for creates / updates, adds local persistence. Adds a UI to be able to create and manage workflows - which enables operator use. 

`/workflows/new`

<img width="934" alt="image" src="https://github.com/user-attachments/assets/aff94acf-577b-4f5f-803c-63ca0beb571f" />

`/worklows`
<img width="1371" alt="image" src="https://github.com/user-attachments/assets/093a4b50-76f9-4498-9dc8-231c70c781b3" />

`/workflows/[id]` 
<img width="952" alt="image" src="https://github.com/user-attachments/assets/069eefe8-c7f4-4833-9971-d731fd820e39" />


I think we should keep task definition in code for the time being to keep a tight handle on the kinds of tasks needed and the inputs/outputs associated with them. 

open issue - this uses `fs` for persistence at the moment. the better move is to use supabase. i'll add that before merging. 
