### PR TITLE
writes insurance via the write to athena browser task

### DIFF
--- a/app/types/clinical.ts
+++ b/app/types/clinical.ts
@@ -12,7 +12,9 @@ export interface Allergy {
 
 export interface Insurance {
     name: string;
+    planType: 'HMO' | 'PPO' | 'EPO' | 'POS' | 'HDHP';
     policyNumber: string;
+    effectiveDate: string;
     groupNumber: string;
     memberId: string;
 }

--- a/app/workflows/[id]/execute/page.tsx
+++ b/app/workflows/[id]/execute/page.tsx
@@ -98,14 +98,6 @@ export default function ExecuteWorkflowPage() {
         setLogs(prev => [...prev, `[${new Date().toISOString()}] ${message}`]);
     };
 
-    const getWorkflow = async () => {
-        const response = await fetch(`/api/workflow/${params.id}`);
-        if (!response.ok) throw new Error('Failed to fetch workflow');
-        const workflow = await response.json();
-        setWorkflow(workflow);
-        return workflow;
-    };
-
     useEffect(() => {
         const fetchWorkflow = async () => {
             try {
@@ -381,7 +373,7 @@ export default function ExecuteWorkflowPage() {
                         throw new Error(`Extract API error: ${extractResponse.statusText}`);
                     }
                     const insurance = await extractResponse.json();
-                    
+                    setExtractedInsurance(insurance.insurance ? insurance.insurance : null);
                     // Update task with the extracted insurance
                     await updateTask(task.id, {
                         status: TaskStatus.COMPLETED,
@@ -664,6 +656,12 @@ export default function ExecuteWorkflowPage() {
                                         </li>
                                     ))}
                                 </ul>
+                            </div>
+                        )}
+                        {writeToAthenaBrowserInput.field === 'insurance' && extractedInsurance && (
+                            <div className="mt-3 space-y-2">
+                                <p className="text-xs font-medium text-gray-600">Insurance to write:</p>
+                                <p className="text-gray-600">{JSON.stringify(extractedInsurance)}</p>
                             </div>
                         )}
                     </div>

--- a/app/workflows/[id]/execute/page.tsx
+++ b/app/workflows/[id]/execute/page.tsx
@@ -466,7 +466,7 @@ export default function ExecuteWorkflowPage() {
                         browserPrompt = `go to localhost:8000, search for james smith, and go to his profile. once there, save the following allergies to the allergies form, one at a time: ${additionalData}`;
                     } else if (writeToAthenaBrowserInput.field === 'insurance' && useInsurance) {
                         additionalData = JSON.stringify(useInsurance);
-                        browserPrompt = `go to localhost:8000, search for james smith, and go to his profile. once there, save the following insurance to the insurance form: ${additionalData}`;
+                        browserPrompt = `go to localhost:8000, search for james smith, and go to his profile. once there, save the following insurance to the insurance form: ${additionalData}. The end date field is optional to enter; skip it if you don't have it. If asked, the subscriber name is the name given to you. `;
                     } else {
                         throw new Error(`Unsupported field type: ${writeToAthenaBrowserInput.field}`);
                     }


### PR DESCRIPTION
Writes insurance to the mock EMR over the browser. Works with the existing task setup, which tasks instructions for a browser-use task in, reads from application memory, and performs the task. This PR adds insurance-specific typing to make it easy to structure. 

Insurance forms and internal logic will be finicky given the different types of insurance, their required fields etc. Careful prompting and validation will solve most of it.
- e.g. knowing exactly how Athena words insurance will make sure that our browser bot doesn't get stuck on a misnamed field while making progress on transferring information
- e.g. knowing which fields are optional will help us not get stuck if the user doesn't input all information. 

<img width="870" alt="image" src="https://github.com/user-attachments/assets/0e141787-631d-4a56-8aec-6fcbc8292676" />


```
export interface Insurance {
    name: string;
    planType: 'HMO' | 'PPO' | 'EPO' | 'POS' | 'HDHP';
    policyNumber: string;
    effectiveDate: string;
    groupNumber: string;
    memberId: string;
}
```

