### PR TITLE
docker can communicate with host google chrome

### DIFF
--- a/browser_service/server.py
+++ b/browser_service/server.py
@@ -27,22 +27,37 @@ os.makedirs(static_dir, exist_ok=True)
 app.mount("/static", StaticFiles(directory=static_dir), name="static")
 app.mount("/browser-agent/static", StaticFiles(directory=static_dir), name="browser_agent_static")
 
-class Command(BaseModel):
-    """Command to be executed in a browser session"""
-    prompt: str
-    description: Optional[str] = None
-    id: Optional[str] = None
+# Browser configuration from environment
+CONNECTION_MODE = os.getenv('CONNECTION_MODE', 'cdp')  # Options: application, cdp
+CHROME_HOST = os.getenv('CHROME_HOST', 'localhost')
+CHROME_PORT = os.getenv('CHROME_PORT', '9222')
+CHROME_CDP_URL = os.getenv('CHROME_CDP_URL', f'http://{CHROME_HOST}:{CHROME_PORT}')
+HEADLESS = os.getenv('HEADLESS', 'False').lower() == 'true'
+DEBUG = os.getenv('DEBUG', 'False').lower() == 'true'
 
-class SessionCreate(BaseModel):
-    command: Command = None
+# Check if running in Docker by looking for container environment
+def is_running_in_docker():
+    try:
+        with open('/proc/self/cgroup', 'r') as f:
+            return any('docker' in line for line in f)
+    except:
+        return False
 
-def get_browser():
-    # Determine Chrome path based on operating system
+# Determine if we should use CDP to connect to host Chrome
+in_docker = is_running_in_docker()
+
+if in_docker:
+    # When in Docker, use CDP to connect to Chrome on the host
+    cdp_url = "ws://host.docker.internal:9222"
+    chrome_instance_path = None  # Not needed when using CDP
+else:
+    # When running directly on the host
+    cdp_url = None
     if platform.system() == "Darwin":  # macOS
         chrome_instance_path = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
-    else:  # Linux/Unix (including Docker containers)
+    else:  # Linux/Unix
         chrome_instance_path = '/usr/bin/chromium'
-        
+    
     # Check if the path exists, use alternative if not
     if not os.path.exists(chrome_instance_path):
         if platform.system() == "Darwin":
@@ -52,12 +67,88 @@ def get_browser():
             # Fallback for Linux/Unix
             chrome_instance_path = '/usr/bin/google-chrome'
 
-    browser = Browser(
-        config=BrowserConfig(
-            chrome_instance_path=chrome_instance_path
-        )
-    )
-    return browser
+def get_chrome_path():
+    """Get the Chrome executable path based on the platform"""
+    if platform.system() == "Darwin":  # macOS
+        paths = [
+            '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+            '/Applications/Chromium.app/Contents/MacOS/Chromium'
+        ]
+    else:  # Linux/Unix
+        paths = [
+            '/usr/bin/google-chrome',
+            '/usr/bin/chromium',
+            '/usr/bin/chromium-browser'
+        ]
+    
+    for path in paths:
+        if os.path.exists(path):
+            return path
+    
+    raise Exception("Chrome/Chromium not found in standard locations")
+
+def get_browser():
+    """Get a browser instance based on the configured connection mode"""
+    print(f"\n=== Browser Configuration ===")
+    print(f"Connection Mode: {CONNECTION_MODE}")
+    print(f"Chrome Host: {CHROME_HOST}")
+    print(f"Chrome Port: {CHROME_PORT}")
+    print(f"Chrome CDP URL: {CHROME_CDP_URL}")
+    print(f"Headless Mode: {HEADLESS}")
+    print(f"Debug Mode: {DEBUG}")
+    print(f"Running in Docker: {is_running_in_docker()}")
+    
+    try:
+        if CONNECTION_MODE == 'cdp':
+            print(f"Connecting to Chrome using CDP URL: {CHROME_CDP_URL}")
+            chrome_path = None
+            cdp_url = CHROME_CDP_URL
+            
+            browser = Browser(
+                config=BrowserConfig(
+                    cdp_url=cdp_url
+                )
+            )
+            
+        elif CONNECTION_MODE == 'application':
+            print("Starting Chrome as an application")
+            chrome_path = get_chrome_path()
+            cdp_url = None
+            launch_args = []
+            
+            if HEADLESS:
+                print("Using headless mode")
+                launch_args.append('--headless=new')  # Modern headless mode
+                
+            browser = Browser(
+                config=BrowserConfig(
+                    chrome_instance_path=chrome_path,
+                    launch_args=launch_args
+                )
+            )
+            
+        else:
+            raise ValueError(f"Invalid CONNECTION_MODE: {CONNECTION_MODE}")
+        
+        print(f"\n=== Browser Instance Created ===")
+        print(f"Chrome Path: {chrome_path or 'Not used'}")
+        print(f"CDP URL: {cdp_url or 'Not used'}")
+        print(f"=== End Browser Configuration ===\n")
+        
+        return browser
+            
+    except Exception as e:
+        print(f"Error initializing browser: {e}")
+        raise
+
+class Command(BaseModel):
+    """Command to be executed in a browser session"""
+    prompt: str
+    description: Optional[str] = None
+    id: Optional[str] = None
+
+class SessionCreate(BaseModel):
+    command: Command = None
 
 class BrowserSession:
     def __init__(self):
@@ -286,7 +377,7 @@ async def get_debug_ui():
             // Determine if we're being accessed through Next.js
             const isNextJs = window.location.pathname.startsWith('/browser-agent');
             // API calls always use /api/browser-agent when through Next.js
-            const apiBaseUrl = isNextJs ? '/api/browser-agent' : '/api/browser-agent';
+            const apiBaseUrl = isNextJs ? '/api/browser-agent' : '/browser-agent';
             // Static files use /browser-agent/static when through Next.js
             const staticBaseUrl = isNextJs ? '/browser-agent/static' : '/static';
         </script>
@@ -407,7 +498,7 @@ async def get_debug_ui():
     
     return HTMLResponse(content=html)
 
-@app.post("/api/browser-agent/session")
+@app.post("/browser-agent/session")
 async def create_session(data: SessionCreate):
     """Create a new browser session"""
     try:
@@ -439,7 +530,7 @@ async def create_session(data: SessionCreate):
         print("getting create session error" + str(e))
         raise HTTPException(status_code=500, detail=str(e))
 
-@app.post("/api/browser-agent/{session_id}/command")
+@app.post("/browser-agent/{session_id}/command")
 async def send_command(session_id: str, command: Command):
     """Send a command to an existing session"""
     if session_id not in sessions:
@@ -463,7 +554,7 @@ async def send_command(session_id: str, command: Command):
         "session_id": session_id
     }
 
-@app.get("/api/browser-agent/{session_id}/commands")
+@app.get("/browser-agent/{session_id}/commands")
 async def get_command_history(session_id: str):
     """Get command history for a session"""
     if session_id not in sessions:
@@ -472,7 +563,7 @@ async def get_command_history(session_id: str):
     browser_session = sessions[session_id]
     return browser_session.get_command_history()
 
-@app.get("/api/browser-agent/{session_id}/state")
+@app.get("/browser-agent/{session_id}/state")
 async def get_session_state(session_id: str):
     """Get full session state"""
     if session_id not in sessions:
@@ -481,7 +572,7 @@ async def get_session_state(session_id: str):
     browser_session = sessions[session_id]
     return browser_session.get_state()
 
-@app.delete("/api/browser-agent/{session_id}")
+@app.delete("/browser-agent/{session_id}")
 async def end_session(session_id: str):
     """End a session"""
     if session_id not in sessions:
@@ -492,7 +583,7 @@ async def end_session(session_id: str):
     del sessions[session_id]
     return {"status": "success"}
 
-@app.get("/api/browser-agent/sessions")
+@app.get("/browser-agent/sessions")
 async def list_sessions():
     """List all active sessions"""
     return [

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,11 @@ services:
       - STORAGE_TYPE=memory
       
       # Browser service configuration
-      - HEADLESS=True
+      - CONNECTION_MODE=${CONNECTION_MODE:-cdp}  # Options: application, cdp
+      - CHROME_HOST=${CHROME_HOST:-host.docker.internal}
+      - CHROME_PORT=${CHROME_PORT:-9222}
+      - CHROME_CDP_URL=${CHROME_CDP_URL:-} # looks like ws://host.docker.internal:9222/devtools/browser/14721d96-6cf2-40f1-a873-6150cfc33a13
+      - HEADLESS=${HEADLESS:-False}
       - VIEWPORT_WIDTH=1280
       - VIEWPORT_HEIGHT=720
       - DEBUG=${DEBUG:-False}

--- a/start-browser-service.sh
+++ b/start-browser-service.sh
@@ -8,5 +8,17 @@ source venv/bin/activate;
 
 cd ..
 
+# Load environment variables from .env file if it exists
+if [ -f .env ]; then
+    echo "Loading environment variables from .env file"
+    export $(grep -v '^#' .env | xargs)
+fi
+
+# Set default connection mode if not specified
+if [ -z "$CONNECTION_MODE" ]; then
+    export CONNECTION_MODE="application"
+    echo "Setting default CONNECTION_MODE to 'application'"
+fi
+
 # Start the FastAPI server using uvicorn
 python -m uvicorn browser_service.server:app --reload --port 3001


### PR DESCRIPTION
Our browser agent can hit our host's (Macbook in this case) Chrome reliably. 

This is an important learning PR because we want to be able to maintain stable relationships with the browser across different container and network topographies. 

Easiest things to read to see what's happening are the new configuration that drives all this  (line 30-36 in the updated `server.py`). We can pick between CDP (Chrome Developer Protocol) and Application (point me to the app via the OS's file path). We can choose headless or not. We can execute this from inside a Docker box.

The production browser service will also live inside a docker box, instead of being on my macbook, but this unblocks us getting there.

The big hold up was that `browser-use`'s cdp_url works with an `http` pointer to chrome locally, but not through docker. additionally, its `wss` url doesn't work directly or from docker. but, counterintuitively, providing a websocket to `cdp` from docker ALSO works. Found this out by mashing variables.