### PR TITLE
Browser Service Uses Bedrock

### DIFF
--- a/browser_service/quick_bedrock_test.py
+++ b/browser_service/quick_bedrock_test.py
@@ -1,0 +1,47 @@
+# Use the API to send a text message to DeepSeek-R1.
+
+import boto3
+import json
+
+from botocore.exceptions import ClientError
+
+# Create a Bedrock Runtime client in the AWS Region of your choice.
+client = boto3.client("bedrock-runtime", region_name="us-east-1")
+
+# Set the cross region inference profile ID for DeepSeek-R1
+model_id = "us.deepseek.r1-v1:0"
+
+# Define the prompt for the model.
+prompt = "Describe the purpose of a 'hello world' program in one line."
+
+# Embed the prompt in DeepSeek-R1's instruction format.
+formatted_prompt = f"""
+<｜begin▁of▁sentence｜><｜User｜>{prompt}<｜Assistant｜><think>\n
+"""
+
+body = json.dumps({
+    "prompt": formatted_prompt,
+    "max_tokens": 512,
+    "temperature": 0.5,
+    "top_p": 0.9,
+})
+
+try:
+    # Invoke the model with the request.
+    response = client.invoke_model(modelId=model_id, body=body)
+
+    # Read the response body.
+    model_response = json.loads(response["body"].read())
+    
+    # Extract choices.
+    choices = model_response["choices"]
+    
+    # Print choices.
+    for index, choice in enumerate(choices):
+        print(f"Choice {index + 1}\n----------")
+        print(f"Text:\n{choice['text']}\n")
+        print(f"Stop reason: {choice['stop_reason']}\n")
+except (ClientError, Exception) as e:
+    print(f"ERROR: Can't invoke '{model_id}'. Reason: {e}")
+    exit(1)
+

--- a/browser_service/quick_bedrock_test_anthropic.py
+++ b/browser_service/quick_bedrock_test_anthropic.py
@@ -1,0 +1,37 @@
+# Use the Conversation API to send a text message to Anthropic Claude.
+
+import boto3
+from botocore.exceptions import ClientError
+
+# Create a Bedrock Runtime client in the AWS Region you want to use.
+client = boto3.client("bedrock-runtime", region_name="us-east-1")
+
+# Set the model ID, e.g., Claude 3 Haiku.
+model_id = "us.anthropic.claude-3-5-haiku-20241022-v1:0"
+
+# Start a conversation with the user message.
+user_message = "Describe the purpose of a 'hello world' program in one line."
+conversation = [
+    {
+        "role": "user",
+        "content": [{"text": user_message}],
+    }
+]
+
+try:
+    # Send the message to the model, using a basic inference configuration.
+    response = client.converse(
+        modelId=model_id,
+        messages=conversation,
+        inferenceConfig={"maxTokens": 512, "temperature": 0.5, "topP": 0.9},
+    )
+
+    # Extract and print the response text.
+    response_text = response["output"]["message"]["content"][0]["text"]
+    print(response_text)
+
+except (ClientError, Exception) as e:
+    print(f"ERROR: Can't invoke '{model_id}'. Reason: {e}")
+    exit(1)
+
+

--- a/browser_service/quick_bedrock_test_anthropic.py
+++ b/browser_service/quick_bedrock_test_anthropic.py
@@ -7,7 +7,7 @@ from botocore.exceptions import ClientError
 client = boto3.client("bedrock-runtime", region_name="us-east-1")
 
 # Set the model ID, e.g., Claude 3 Haiku.
-model_id = "us.anthropic.claude-3-5-haiku-20241022-v1:0"
+model_id = "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
 
 # Start a conversation with the user message.
 user_message = "Describe the purpose of a 'hello world' program in one line."


### PR DESCRIPTION
Per [jam](https://docs.google.com/document/d/1S_9XNhFmy-HwAuUF-njBTsVv5vJ9cw_KfiKIeFvvuV0/edit?tab=t.0#bookmark=id.lw6zctixzp7x) and discussion in slack, we're using Bedrock (covered by an active BAA from Amazon), to run inference. 

We'd ideally like to use DeepSeek or a similar open source model to power our inference.  We can use DeepSeek based on direct calls to Bedrock (which is awesome)! Langchain, which browser-use uses heavily to define x-LLM interfaces, [chokes](https://github.com/langchain-ai/langchain-aws/blob/31938868346ead977c5d333a8628122dc201d55e/libs/aws/langchain_aws/chat_models/bedrock.py#L939) on non-Claude usage on bedrock. I will remedy this later by writing an adapator for DeepSeek, but it's good to get going with test case validation. 

<img width="1426" alt="image" src="https://github.com/user-attachments/assets/4edf617b-b6c0-4be7-8ff7-78e1441ec88c" />

This PR also adds configuration for browser-service, allowing you to choose the LLM you're using. 
<img width="1882" alt="image" src="https://github.com/user-attachments/assets/d8fc8747-b0cb-4d27-844d-aea4b801f16a" />


